### PR TITLE
Only spawn entities where it's reachable

### DIFF
--- a/src/map_builder/automata.rs
+++ b/src/map_builder/automata.rs
@@ -84,9 +84,9 @@ impl MapArchitect for CellularAutomataArchitect {
         }
         let start = self.find_start(&mb.map);
 
-        mb.monster_spawns = mb.spawn_monster(&start, rng);
         mb.player_start = start;
         mb.amulet_start = mb.find_most_distance();
+        mb.monster_spawns = mb.spawn_monster(rng);
 
         mb
     }

--- a/src/map_builder/drunkard.rs
+++ b/src/map_builder/drunkard.rs
@@ -78,9 +78,10 @@ impl MapArchitect for DrunkardWalkArchitect {
                 .for_each(|(idx, _)| mb.map.tiles[idx] = TileType::Wall);
         }
 
-        mb.monster_spawns = mb.spawn_monster(&center, rng);
         mb.player_start = center;
         mb.amulet_start = mb.find_most_distance();
+        mb.monster_spawns = mb.spawn_monster(rng);
+
         mb
     }
 }

--- a/src/map_builder/mod.rs
+++ b/src/map_builder/mod.rs
@@ -55,13 +55,7 @@ impl MapBuilder {
     }
 
     fn find_most_distance(&self) -> Point {
-        let dijkstra_map = DijkstraMap::new(
-            SCREEN_WIDTH,
-            SCREEN_HEIGHT,
-            &[self.map.point2d_to_index(self.player_start)],
-            &self.map,
-            1024.0,
-        );
+        let dijkstra_map = self.build_player_distance_map();
 
         const UNREACHABLE: &f32 = &f32::MAX;
         self.map.index_to_point2d(
@@ -76,17 +70,32 @@ impl MapBuilder {
         )
     }
 
-    fn spawn_monster(&self, start: &Point, rng: &mut RandomNumberGenerator) -> Vec<Point> {
+    fn build_player_distance_map(&self) -> DijkstraMap {
+        DijkstraMap::new(
+            SCREEN_WIDTH,
+            SCREEN_HEIGHT,
+            &[self.map.point2d_to_index(self.player_start)],
+            &self.map,
+            1024.0,
+        )
+    }
+
+    /// Should be called only after self.player_start is set.
+    fn spawn_monster(&self, rng: &mut RandomNumberGenerator) -> Vec<Point> {
         const NUM_MONSTERS: usize = 50;
+        const UNREACHABLE: f32 = f32::MAX;
+        let dijkstra_map = self.build_player_distance_map();
         let mut spawnable_tiles: Vec<Point> = self
             .map
             .tiles
             .iter()
             .enumerate()
+            // Only spawn in Floors and in places that are reachable by the player
+            // but not too close to the start position.
             .filter(|(idx, t)| {
                 **t == TileType::Floor
-                    && DistanceAlg::Pythagoras.distance2d(*start, self.map.index_to_point2d(*idx))
-                        > 10.0
+                    && dijkstra_map.map[*idx] >= 10.0
+                    && dijkstra_map.map[*idx] < UNREACHABLE
             })
             .map(|(idx, _)| self.map.index_to_point2d(idx))
             .collect();


### PR DESCRIPTION
Use the same technique we already use to spawn the exit/amulet and
check the computed dijkstra distance map from the player start to
trim out any unreachable tile.

Fixes #14