### PR TITLE
Generate maps only with Wall borders

### DIFF
--- a/src/map_builder/automata.rs
+++ b/src/map_builder/automata.rs
@@ -3,19 +3,26 @@ use crate::prelude::*;
 
 pub struct CellularAutomataArchitect {}
 
-// TODO: Make sure the boundaries/borders of the map are Walls.
 // TODO: Don't spawn monsters in areas that are not reachable by the player.
 //       Maybe conside turning those areas into Walls too?
 impl CellularAutomataArchitect {
     fn random_noise_map(&mut self, rng: &mut RandomNumberGenerator, map: &mut Map) {
-        map.tiles.iter_mut().for_each(|t| {
-            let roll = rng.range(0, 100);
-            *t = if roll > 55 {
-                TileType::Floor
+        let mut new_tiles = map.tiles.clone();
+        new_tiles.iter_mut().enumerate().for_each(|(idx, t)| {
+            let pt = map.index_to_point2d(idx);
+            if pt.x == 0 || pt.x == SCREEN_WIDTH || pt.y == 0 || pt.y == SCREEN_HEIGHT - 1 {
+                // Always make the borders be Walls.
+                *t = TileType::Wall
             } else {
-                TileType::Wall
-            };
+                let roll = rng.range(0, 100);
+                *t = if roll > 55 {
+                    TileType::Floor
+                } else {
+                    TileType::Wall
+                };
+            }
         });
+        map.tiles = new_tiles;
     }
 
     /// Count number of adjacent (incl diagonals) Wall tiles.

--- a/src/map_builder/drunkard.rs
+++ b/src/map_builder/drunkard.rs
@@ -14,16 +14,22 @@ impl DrunkardWalkArchitect {
 
         loop {
             let drunk_idx = map.point2d_to_index(drunkard_pos);
-            map.tiles[drunk_idx] = TileType::Floor;
+            // Break if arrived in a border (or is fully out of bounds)
+            if !map.in_bounds(drunkard_pos)
+                || drunkard_pos.x == 0
+                || drunkard_pos.x == SCREEN_WIDTH - 1
+                || drunkard_pos.y == 0
+                || drunkard_pos.y == SCREEN_HEIGHT - 1
+            {
+                break;
+            }
 
+            map.tiles[drunk_idx] = TileType::Floor;
             match rng.range(0, 4) {
                 0 => drunkard_pos.x -= 1,
                 1 => drunkard_pos.x += 1,
                 2 => drunkard_pos.y -= 1,
                 _ => drunkard_pos.y += 1,
-            }
-            if !map.in_bounds(drunkard_pos) {
-                break;
             }
 
             distance_staggered += 1;
@@ -58,7 +64,10 @@ impl MapArchitect for DrunkardWalkArchitect {
             < DESIRED_FLOOR
         {
             self.drunkard(
-                &Point::new(rng.range(0, SCREEN_WIDTH), rng.range(0, SCREEN_HEIGHT)),
+                &Point::new(
+                    rng.range(1, SCREEN_WIDTH - 1),
+                    rng.range(1, SCREEN_HEIGHT - 1),
+                ),
                 rng,
                 &mut mb.map,
             );


### PR DESCRIPTION
For the Automata generator, we make sure that the border tiles start as
Walls, since after that each iteration do not change them already.

For the Drunkard generator, we break the iteration when we arrive at the
border. Potentially we could adjust the RNG to never go into a border
instead, this way each drunk walk iteration would live for longer but this
would make the logic way more complicated and I'm not sure it would
yield better results.

Fixes #6